### PR TITLE
Change: Correct match for flow control keywords

### DIFF
--- a/CFEngine3.tmLanguage
+++ b/CFEngine3.tmLanguage
@@ -183,7 +183,7 @@
             <key>comment</key>
             <string>keywords that delimit flow blocks or alter flow from within a block</string>
             <key>match</key>
-            <string>\b(elif|else|except|finally|for|if|try|while|with|break|continue|pass|raise|return|yield)\b</string>
+            <string>\b([().&!|:a-zA-Z_]+)\:\:[\s+|\n]</string>
             <key>name</key>
             <string>keyword.control.flow.cfengine</string>
         </dict>


### PR DESCRIPTION
CFEngine uses class expressions for decision making and flow control.

Screen-shot: http://i.imgur.com/o4AwEyX.jpg
