### PR TITLE
Add: Users type promise to 'builtin_functions'

### DIFF
--- a/CFEngine3.tmLanguage
+++ b/CFEngine3.tmLanguage
@@ -1198,7 +1198,7 @@
         <dict>
             <key>match</key>
             <string>(?x)\b(
-                all|linux|debian|any|cfengine|vars|defaults|roles|access|files|services|packages|processes|commands|guest_environments|measurements|databases|reports|acl|alerts|binservers|broadcast|control|main|classes|copy|defaultroute|disks|directories|disable|editfiles|files|filters|groups|homeservers|ignore|import|interfaces|links|mailserver|methods|miscmounts|mountables|processes|packages|rename|required|resolve|shellcommands|tidy|unmount|redhat|ubuntu|gentoo|storage
+                all|linux|debian|any|cfengine|vars|users|defaults|roles|access|files|services|packages|processes|commands|guest_environments|measurements|databases|reports|acl|alerts|binservers|broadcast|control|main|classes|copy|defaultroute|disks|directories|disable|editfiles|files|filters|groups|homeservers|ignore|import|interfaces|links|mailserver|methods|miscmounts|mountables|processes|packages|rename|required|resolve|shellcommands|tidy|unmount|redhat|ubuntu|gentoo|storage
             )\b</string>
             <key>name</key>
             <string>support.function.builtin.cfengine</string>


### PR DESCRIPTION
Users type promsie was added in CFEngine 3.6. This allows it to be highlighted
like vars, commands, or any other promise type.
